### PR TITLE
Add command-line flag for config file path

### DIFF
--- a/config.go
+++ b/config.go
@@ -45,17 +45,21 @@ func NewDefaultConfig() Config {
 	}
 }
 
-// LoadConfig loads configuration from mydatasyncer.yml file
+// LoadConfig loads configuration from file specified by configPath
 // Falls back to default configuration if the file doesn't exist or contains errors
-func LoadConfig() Config {
+func LoadConfig(configPath string) Config {
+	// If no config path is provided, use the default
+	if configPath == "" {
+		configPath = "mydatasyncer.yml"
+	}
+
 	// Check for the config file
-	configPath := "mydatasyncer.yml" // Updated config file name
 	data, err := os.ReadFile(configPath)
 
 	// If config file not found or error reading, use default configuration
 	if err != nil {
 		if os.IsNotExist(err) {
-			fmt.Println("Config file 'mydatasyncer.yml' not found. Using default configuration.")
+			fmt.Printf("Config file '%s' not found. Using default configuration.\n", configPath)
 		} else {
 			fmt.Printf("Warning: Error reading config file %s: %v\n", configPath, err)
 			fmt.Println("Using default configuration")

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"database/sql"
+	"flag"
 	"log"
 	"time"
 
@@ -10,12 +11,16 @@ import (
 )
 
 func main() {
+	// Define command-line flags
+	configPath := flag.String("config", "", "Path to configuration file (default: mydatasyncer.yml)")
+	flag.Parse()
+
 	// Create a context with timeout for the entire process
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
 	// 1. Load configuration
-	config := LoadConfig()
+	config := LoadConfig(*configPath)
 	if err := ValidateConfig(config); err != nil {
 		log.Fatalf("Configuration error: %v", err)
 	}


### PR DESCRIPTION
## Overview
This PR adds the ability to specify a configuration file path via command-line arguments.

## Changes
- Modified `LoadConfig()` function to accept a configuration file path parameter
- Added command-line flag `-config` using Go's flag package
- Updated default behavior to use "mydatasyncer.yml" when no path is specified

## How to use
```
./mydatasyncer -config /path/to/custom-config.yml
```

## Testing
- Manually tested with different configuration files
- Default behavior is preserved when no `-config` flag is provided