### PR TITLE
Add immutable columns feature

### DIFF
--- a/config.go
+++ b/config.go
@@ -14,12 +14,14 @@ type DBConfig struct {
 
 // SyncConfig represents data synchronization settings
 type SyncConfig struct {
-	FilePath        string   `yaml:"filePath"`        // Input file path
-	TableName       string   `yaml:"tableName"`       // Target table name
-	Columns         []string `yaml:"columns"`         // DB column names corresponding to file columns (order is important)
-	PrimaryKey      string   `yaml:"primaryKey"`      // Primary key column name (required for differential update)
-	SyncMode        string   `yaml:"syncMode"`        // "overwrite" or "diff" (differential)
-	DeleteNotInFile bool     `yaml:"deleteNotInFile"` // Whether to delete records not in file when using diff mode
+	FilePath         string   `yaml:"filePath"`         // Input file path
+	TableName        string   `yaml:"tableName"`        // Target table name
+	Columns          []string `yaml:"columns"`          // DB column names corresponding to file columns (order is important)
+	TimestampColumns []string `yaml:"timestampColumns"` // Column names to set current timestamp on insert/update
+	ImmutableColumns []string `yaml:"immutableColumns"` // Column names that should not be updated in diff mode
+	PrimaryKey       string   `yaml:"primaryKey"`       // Primary key column name (required for differential update)
+	SyncMode         string   `yaml:"syncMode"`         // "overwrite" or "diff" (differential)
+	DeleteNotInFile  bool     `yaml:"deleteNotInFile"`  // Whether to delete records not in file when using diff mode
 }
 
 // Config represents configuration information
@@ -35,12 +37,14 @@ func NewDefaultConfig() Config {
 			DSN: "user:password@tcp(127.0.0.1:3306)/testdb?parseTime=true",
 		},
 		Sync: SyncConfig{
-			FilePath:        "./testdata.csv",
-			TableName:       "products",
-			Columns:         []string{"id", "name", "price"}, // Match CSV column order
-			PrimaryKey:      "id",
-			SyncMode:        "diff", // "overwrite" or "diff"
-			DeleteNotInFile: true,
+			FilePath:         "./testdata.csv",
+			TableName:        "products",
+			Columns:          []string{"id", "name", "price"}, // Match CSV column order
+			PrimaryKey:       "id",
+			SyncMode:         "diff", // "overwrite" or "diff"
+			DeleteNotInFile:  true,
+			TimestampColumns: []string{}, // Default to empty slice
+			ImmutableColumns: []string{}, // Default to empty slice
 		},
 	}
 }

--- a/dbsync.go
+++ b/dbsync.go
@@ -5,7 +5,9 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
+	"slices"
 	"strings"
+	"time"
 )
 
 // syncData synchronizes data between file and database
@@ -250,23 +252,43 @@ func bulkInsert(ctx context.Context, tx *sql.Tx, config Config, records []DataRe
 	if len(records) == 0 {
 		return nil
 	}
+
+	// Prepare columns list including timestamp columns
+	allColumns := append([]string{}, config.Sync.Columns...)
+	for _, tsCol := range config.Sync.TimestampColumns {
+		if !slices.Contains(allColumns, tsCol) {
+			allColumns = append(allColumns, tsCol)
+		}
+	}
+
 	valueStrings := make([]string, 0, len(records))
-	valueArgs := make([]any, 0, len(records)*len(config.Sync.Columns))
-	placeholders := make([]string, len(config.Sync.Columns))
+	valueArgs := make([]any, 0, len(records)*len(allColumns))
+	placeholders := make([]string, len(allColumns))
 	for i := range placeholders {
 		placeholders[i] = "?"
 	}
 	placeholderStr := fmt.Sprintf("(%s)", strings.Join(placeholders, ","))
 
+	now := time.Now()
 	for _, record := range records {
 		valueStrings = append(valueStrings, placeholderStr)
+
+		// Add values from source data
 		for _, col := range config.Sync.Columns {
 			valueArgs = append(valueArgs, record[col])
 		}
+
+		// Add current timestamp for timestamp columns
+		for _, tsCol := range config.Sync.TimestampColumns {
+			if slices.Contains(allColumns, tsCol) {
+				valueArgs = append(valueArgs, now)
+			}
+		}
 	}
+
 	stmt := fmt.Sprintf("INSERT INTO %s (%s) VALUES %s",
 		config.Sync.TableName,
-		strings.Join(config.Sync.Columns, ","),
+		strings.Join(allColumns, ","),
 		strings.Join(valueStrings, ","))
 	_, err := tx.ExecContext(ctx, stmt, valueArgs...)
 	return err
@@ -278,10 +300,21 @@ func bulkUpdate(ctx context.Context, tx *sql.Tx, config Config, records []DataRe
 		return nil
 	}
 	// Simple example: Update one by one (inefficient)
-	updateCols := make([]string, 0, len(config.Sync.Columns))
+	// Prepare update columns
+	updateCols := make([]string, 0, len(config.Sync.Columns)+len(config.Sync.TimestampColumns))
+
+	// Add columns from source data
 	for _, col := range config.Sync.Columns {
-		if col != config.Sync.PrimaryKey { // Don't include primary key in SET clause
+		// Don't include primary key or immutable columns in SET clause
+		if col != config.Sync.PrimaryKey && !slices.Contains(config.Sync.ImmutableColumns, col) {
 			updateCols = append(updateCols, fmt.Sprintf("%s = ?", col))
+		}
+	}
+
+	// Add timestamp columns (except immutable ones)
+	for _, tsCol := range config.Sync.TimestampColumns {
+		if tsCol != config.Sync.PrimaryKey && !slices.Contains(config.Sync.Columns, tsCol) && !slices.Contains(config.Sync.ImmutableColumns, tsCol) {
+			updateCols = append(updateCols, fmt.Sprintf("%s = ?", tsCol))
 		}
 	}
 	if len(updateCols) == 0 {
@@ -301,10 +334,20 @@ func bulkUpdate(ctx context.Context, tx *sql.Tx, config Config, records []DataRe
 	defer stmt.Close()
 
 	for _, record := range records {
-		args := make([]any, 0, len(config.Sync.Columns))
+		now := time.Now()
+		args := make([]any, 0, len(config.Sync.Columns)+len(config.Sync.TimestampColumns))
+
+		// Add values from source data
 		for _, col := range config.Sync.Columns {
-			if col != config.Sync.PrimaryKey {
+			if col != config.Sync.PrimaryKey && !slices.Contains(config.Sync.ImmutableColumns, col) {
 				args = append(args, record[col])
+			}
+		}
+
+		// Add current timestamp for timestamp columns (except immutable ones)
+		for _, tsCol := range config.Sync.TimestampColumns {
+			if tsCol != config.Sync.PrimaryKey && !slices.Contains(config.Sync.Columns, tsCol) && !slices.Contains(config.Sync.ImmutableColumns, tsCol) {
+				args = append(args, now)
 			}
 		}
 		args = append(args, record[config.Sync.PrimaryKey]) // Primary key for WHERE clause

--- a/init-sql/01_create_tables.sql
+++ b/init-sql/01_create_tables.sql
@@ -6,15 +6,17 @@ CREATE TABLE products (
   id VARCHAR(50) NOT NULL,
   name VARCHAR(100) NOT NULL,
   price VARCHAR(20) NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
   PRIMARY KEY (id)
 ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
 -- Insert sample data
 INSERT INTO
-  products (id, name, price)
+  products (id, name, price, created_at, updated_at)
 VALUES
-  ('P001', 'Product 1', '1000'),
-  ('P002', 'Product 2', '2000'),
-  ('P003', 'Product 3', '3000');
+  ('P001', 'Product 1', '1000', NOW(), NOW()),
+  ('P002', 'Product 2', '2000', NOW(), NOW()),
+  ('P003', 'Product 3', '3000', NOW(), NOW());
 
 -- Define additional tables here if needed

--- a/mydatasyncer.yml
+++ b/mydatasyncer.yml
@@ -36,3 +36,20 @@ sync:
   # If set to true, data in the database with a primary key that doesn't exist in the file will be deleted.
   # If set to false, such data will not be deleted.
   deleteNotInFile: true
+
+  # Columns to automatically set current timestamp
+  # When specified, these columns will be set to the current time on insert/update
+  # Example usage:
+  #   - For new records: both created_at and updated_at will be set
+  #   - For updated records: only updated_at will be set
+  timestampColumns:
+    - "created_at"
+    - "updated_at"
+
+  # Columns that should not be updated in diff mode
+  # These columns will keep their original values when records are updated
+  # Example usage:
+  #   - Protect sensitive fields from being overwritten
+  #   - Maintain historical data like 'created_at'
+  immutableColumns:
+    - "created_at" # Protect creation timestamp from updates


### PR DESCRIPTION
## Overview
This PR adds the ability to protect specific columns from being updated during differential synchronization, along with automatic timestamp management.

## Features
- Added `ImmutableColumns` configuration to specify columns that should not be updated in diff mode
- Added `TimestampColumns` configuration for automatic timestamp management
- Implemented protection logic in `bulkUpdate` to exclude immutable columns
- Added timestamp update logic for both insert and update operations

## Configuration Example
```yaml
sync:
  timestampColumns:
    - "created_at"  # Set on creation only
    - "updated_at"  # Set on both creation and update
  immutableColumns:
    - "created_at"  # Protected from updates
```

## Implementation Details
- Created timestamps are set automatically for new records
- Updated timestamps are set automatically for both new and updated records
- Immutable columns keep their original values during updates
- Column protection is enforced at the SQL generation level