### PR TITLE
Add Dry Run Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,102 @@ git clone https://github.com/yoRyuuuuu/mydatasyncer.git
 cd mydatasyncer
 go build
 ```
-
 ## Usage
+
+### Basic Usage
+
+```bash
+mydatasyncer --config config.yml
+```
+
+### Dry Run Mode
+
+The Dry Run mode allows you to preview synchronization changes without actually modifying the database.
+
+#### Overview
+
+Key benefits of the Dry Run feature:
+
+- **Safe Change Preview**: Review synchronization results without affecting the actual database
+- **Detailed Execution Plan**: Check the number of records to be inserted, updated, or deleted, and which columns will be affected
+- **Transaction Protection**: Changes are automatically rolled back in Dry Run mode, ensuring data integrity
+- **Dual Mode Support**: Available in both overwrite and diff modes
+
+#### Usage
+
+1. Command Line Execution:
+```bash
+# Basic usage
+mydatasyncer --config config.yml --dry-run
+
+# Without config path (uses default mydatasyncer.yml)
+mydatasyncer --dry-run
+```
+
+2. Configuration File:
+```yaml
+# mydatasyncer.yml
+db:
+  dsn: "user:password@tcp(127.0.0.1:3306)/testdb?parseTime=true"
+sync:
+  filePath: "./testdata.csv"
+  tableName: "products"
+  columns:
+    - id
+    - name
+    - price
+  primaryKey: "id"
+  syncMode: "diff"
+  deleteNotInFile: true
+```
+
+#### Output Format
+
+The Dry Run mode displays an execution plan in the following format:
+
+```
+[DRY-RUN MODE] Execution Plan for Table {table_name}
+----------------------------------------------------
+Summary:
+- Sync Mode: {overwrite|diff}
+- Records in File: X
+- Records in Database: Y
+
+Planned Operations:
+1. Delete Operations
+   - Records to Delete: N
+   - Affected Primary Keys: [key list]
+
+2. Insert Operations
+   - Records to Insert: M
+   - Affected Columns: [column1, column2, ...]
+
+3. Update Operations
+   - Records to Update: P
+   - Affected Columns: [column1, column2, ...]
+
+Timestamps:
+- Timestamp Columns to Update: [created_at, updated_at]
+```
+
+#### Important Notes
+
+1. **Transaction Control**
+   - All operations in Dry Run mode are automatically rolled back
+   - No actual database changes are made during execution
+
+2. **Timestamp Columns**
+   - Timestamp columns (created_at, updated_at) are included in the execution plan
+   - Actual values will be set automatically during real execution
+
+3. **Performance**
+   - Minimal performance overhead even with large datasets
+   - Efficient execution plan generation with minimal database impact
+
+4. **Error Handling**
+   - Configuration and connection errors are detected before execution
+   - Error messages are displayed in a clear, understandable format
+
 
 ### Basic Usage
 

--- a/config.go
+++ b/config.go
@@ -26,8 +26,9 @@ type SyncConfig struct {
 
 // Config represents configuration information
 type Config struct {
-	DB   DBConfig   `yaml:"db"`
-	Sync SyncConfig `yaml:"sync"`
+	DB     DBConfig   `yaml:"db"`
+	Sync   SyncConfig `yaml:"sync"`
+	DryRun bool       `yaml:"dryRun"` // Enable dry-run mode
 }
 
 // NewDefaultConfig returns a Config struct with default values
@@ -112,6 +113,8 @@ func setDefaultsIfNeeded(cfg *Config) {
 	if cfg.Sync.SyncMode == "" {
 		cfg.Sync.SyncMode = defaultCfg.Sync.SyncMode
 	}
+
+	// Note: DryRun is a bool, so it will default to false if not specified in the config
 }
 
 // ValidateConfig checks if the configuration has all required values

--- a/dbsync.go
+++ b/dbsync.go
@@ -300,7 +300,8 @@ func syncDiff(ctx context.Context, tx *sql.Tx, config Config, fileRecords []Data
 
 	// 4. UPDATE processing
 	if len(toUpdate) > 0 {
-		// Convert UpdateOperation to DataRecord for bulkUpdate
+		// Transform the UpdateOperation slice into a DataRecord slice.
+		// This is necessary because the bulkUpdate function requires a slice of DataRecord as input.
 		updateRecords := make([]DataRecord, len(toUpdate))
 		for i, update := range toUpdate {
 			updateRecords[i] = update.After

--- a/dbsync_test.go
+++ b/dbsync_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	_ "github.com/go-sql-driver/mysql"
@@ -329,7 +330,12 @@ func TestDiffData(t *testing.T) {
 	toInsert, toUpdate, toDelete := diffData(config, fileRecords, dbRecords)
 
 	expectedInsert := []DataRecord{{"id": "4", "name": "test4", "value": "value4"}}
-	expectedUpdate := []DataRecord{{"id": "1", "name": "new1", "value": "new_value1"}}
+	expectedUpdate := []UpdateOperation{
+		{
+			Before: DataRecord{"id": "1", "name": "old1", "value": "old_value1"},
+			After:  DataRecord{"id": "1", "name": "new1", "value": "new_value1"},
+		},
+	}
 	expectedDelete := []DataRecord{{"id": "3", "name": "test3", "value": "value3"}}
 
 	if diff := cmp.Diff(toInsert, expectedInsert); diff != "" {
@@ -340,5 +346,187 @@ func TestDiffData(t *testing.T) {
 	}
 	if diff := cmp.Diff(toDelete, expectedDelete); diff != "" {
 		t.Errorf("Delete mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestDryRunOverwriteMode(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	cleanupTestData(t, db)
+
+	// Setup initial data
+	_, err := db.Exec("INSERT INTO test_table (id, name, value) VALUES (?, ?, ?), (?, ?, ?)",
+		"1", "old1", "old_value1",
+		"2", "old2", "old_value2")
+	if err != nil {
+		t.Fatalf("Failed to insert test data: %v", err)
+	}
+
+	// Setup test config with dry-run enabled
+	config := createTestConfig()
+	config.DryRun = true
+	config.Sync.SyncMode = "overwrite"
+
+	// Test data for overwrite
+	fileRecords := []DataRecord{
+		{"id": "3", "name": "new3", "value": "new_value3"},
+		{"id": "4", "name": "new4", "value": "new_value4"},
+	}
+
+	// Execute dry run
+	err = syncData(context.Background(), db, config, fileRecords)
+	if err != nil {
+		t.Fatalf("Failed to execute dry run: %v", err)
+	}
+
+	// Verify that no changes were made to the database
+	rows, err := db.Query("SELECT id, name, value FROM test_table ORDER BY id")
+	if err != nil {
+		t.Fatalf("Failed to query results: %v", err)
+	}
+	defer rows.Close()
+
+	var result []DataRecord
+	for rows.Next() {
+		var id, name, value string
+		if err := rows.Scan(&id, &name, &value); err != nil {
+			t.Fatalf("Failed to scan row: %v", err)
+		}
+		result = append(result, DataRecord{"id": id, "name": name, "value": value})
+	}
+
+	// Expected data should be unchanged
+	expectedRecords := []DataRecord{
+		{"id": "1", "name": "old1", "value": "old_value1"},
+		{"id": "2", "name": "old2", "value": "old_value2"},
+	}
+
+	if diff := cmp.Diff(result, expectedRecords); diff != "" {
+		t.Errorf("Database was modified in dry-run mode (-want +got):\n%s", diff)
+	}
+}
+
+func TestDryRunDiffMode(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	cleanupTestData(t, db)
+
+	// Setup initial data
+	_, err := db.Exec("INSERT INTO test_table (id, name, value) VALUES (?, ?, ?), (?, ?, ?), (?, ?, ?)",
+		"1", "old1", "old_value1",
+		"2", "old2", "old_value2",
+		"3", "old3", "old_value3")
+	if err != nil {
+		t.Fatalf("Failed to insert test data: %v", err)
+	}
+
+	// Setup test config with dry-run enabled
+	config := createTestConfig()
+	config.DryRun = true
+	config.Sync.SyncMode = "diff"
+
+	// Test data that would cause all types of operations
+	fileRecords := []DataRecord{
+		{"id": "1", "name": "new1", "value": "new_value1"},    // Update
+		{"id": "4", "name": "new4", "value": "new_value4"},    // Insert
+		{"id": "2", "name": "old2", "value": "old_value2"},    // No change
+	}
+
+	// Execute dry run
+	err = syncData(context.Background(), db, config, fileRecords)
+	if err != nil {
+		t.Fatalf("Failed to execute dry run: %v", err)
+	}
+
+	// Verify that no changes were made to the database
+	rows, err := db.Query("SELECT id, name, value FROM test_table ORDER BY id")
+	if err != nil {
+		t.Fatalf("Failed to query results: %v", err)
+	}
+	defer rows.Close()
+
+	var result []DataRecord
+	for rows.Next() {
+		var id, name, value string
+		if err := rows.Scan(&id, &name, &value); err != nil {
+			t.Fatalf("Failed to scan row: %v", err)
+		}
+		result = append(result, DataRecord{"id": id, "name": name, "value": value})
+	}
+
+	// Expected data should be unchanged
+	expectedRecords := []DataRecord{
+		{"id": "1", "name": "old1", "value": "old_value1"},
+		{"id": "2", "name": "old2", "value": "old_value2"},
+		{"id": "3", "name": "old3", "value": "old_value3"},
+	}
+
+	if diff := cmp.Diff(result, expectedRecords); diff != "" {
+		t.Errorf("Database was modified in dry-run mode (-want +got):\n%s", diff)
+	}
+}
+
+func TestExecutionPlanString(t *testing.T) {
+	plan := &ExecutionPlan{
+		SyncMode:        "diff",
+		TableName:       "test_table",
+		FileRecordCount: 3,
+		DbRecordCount:   3,
+		InsertOperations: []DataRecord{
+			{"id": "4", "name": "new4", "value": "new_value4"},
+		},
+		UpdateOperations: []UpdateOperation{
+			{
+				Before: DataRecord{"id": "1", "name": "old1", "value": "old_value1"},
+				After:  DataRecord{"id": "1", "name": "new1", "value": "new_value1"},
+			},
+		},
+		DeleteOperations: []DataRecord{
+			{"id": "3", "name": "old3", "value": "old_value3"},
+		},
+		AffectedColumns:  []string{"id", "name", "value"},
+		TimestampColumns: []string{"created_at", "updated_at"},
+		ImmutableColumns: []string{"created_at"},
+	}
+
+	output := plan.String()
+
+	// Verify that the output contains all necessary sections
+	expectedSections := []string{
+		"[DRY-RUN Mode] Execution Plan",
+		"Sync Mode: diff",
+		"Target Table: test_table",
+		"Records in File: 3",
+		"Records in Database: 3",
+		"DELETE Operations (1 records)",
+		"INSERT Operations (1 records)",
+		"UPDATE Operations (1 records)",
+		"Immutable columns (will not be updated): [created_at]",
+	}
+
+	for _, section := range expectedSections {
+		if !strings.Contains(output, section) {
+			t.Errorf("ExecutionPlan.String() output missing section: %s", section)
+		}
+	}
+
+	// Verify that the output contains operation details
+	expectedDetails := []string{
+		"id: 4",
+		"name: new4",
+		"value: new_value4",
+		"name: old1 -> new1",
+		"value: old_value1 -> new_value1",
+		"id: 3",
+		"name: old3",
+		"value: old_value3",
+	}
+
+	for _, detail := range expectedDetails {
+		if !strings.Contains(output, detail) {
+			t.Errorf("ExecutionPlan.String() output missing detail: %s", detail)
+		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 func main() {
 	// Define command-line flags
 	configPath := flag.String("config", "", "Path to configuration file (default: mydatasyncer.yml)")
+	dryRun := flag.Bool("dry-run", false, "Execute in dry-run mode (preview changes without applying them)")
 	flag.Parse()
 
 	// Create a context with timeout for the entire process
@@ -21,6 +22,12 @@ func main() {
 
 	// 1. Load configuration
 	config := LoadConfig(*configPath)
+	config.DryRun = *dryRun // Set dry-run mode from command line flag
+
+	if *dryRun {
+		log.Println("Running in DRY-RUN mode - No changes will be applied to the database")
+	}
+
 	if err := ValidateConfig(config); err != nil {
 		log.Fatalf("Configuration error: %v", err)
 	}

--- a/mydatasyncer.yml
+++ b/mydatasyncer.yml
@@ -1,3 +1,7 @@
+# Enable dry-run mode
+# If set to true, the tool will only show what changes would be made without actually modifying the database
+dryRun: false
+
 # Database connection settings
 db:
   # Data Source Name (DSN)

--- a/testdata.csv
+++ b/testdata.csv
@@ -1,4 +1,4 @@
 id,name,price
-P001,Product 1 Updated,1500
 P002,Product 2,2000
-P004,New Product 4,4000
+P004,New Product 4,5000
+P005,New Product 5,6000


### PR DESCRIPTION
# Add Dry Run Mode

## Overview
Implemented a dry-run feature that allows users to preview data synchronization operations before actual execution.

## Implementation Details
1. Added Dry Run Configuration
   - Added DryRun field to Config struct
   - Implemented `--dry-run` command line flag

2. Execution Plan Generation and Display
   - Preview of INSERT/UPDATE/DELETE operations
   - Handling of immutable columns
   - Timestamp column processing

3. Transaction Control
   - Rollback handling in dry-run mode
   - Prevention of database modifications

## Test Results
Added and verified the following test cases:
- TestDryRunOverwriteMode
- TestDryRunDiffMode
- TestExecutionPlanString

## Usage

1. Using command line flag:
```bash
mydatasyncer --config config.yml --dry-run
```

2. Using configuration file:
```yaml
dryRun: true
```

## Change History
- feat: add dry-run configuration and command line flag
- feat: implement dry-run execution plan generation and display
- test: add dry-run mode test cases
- docs: update documentation and configuration for dry-run feature